### PR TITLE
feat: add `MakePlatform` field to api

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -4,5 +4,6 @@ module.exports = {
     BaseTech: require('../tech/base-tech'),
     FileList: require('../file-list'),
     buildFlow: require('../build-flow'),
-    asyncFs: require('../fs/async-fs')
+    asyncFs: require('../fs/async-fs'),
+    MakePlatform: require('../make')
 };


### PR DESCRIPTION
For example it is need for `enb-magic-platform`: https://github.com/enb/enb-magic-platform/blob/master/lib/apply.js#L3