### PR TITLE
feat(build-info): add `build-info-file` option to make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ ENB работает гораздо быстрее, чем bem-tools. Приче
 ./node_modules/.bin/enb make --graph
 ```
 
+Сборка всех страниц проекта с включённым профайлером (считает время работы таргетов и технологий):
+```
+./node_modules/.bin/enb make --profiler
+```
+
+Сборка всех страниц проекта и запись данных о сборке (результаты профайлера) в файл:
+```
+./node_modules/.bin/enb make --build-info-file="build-info.json"
+```
+
 Сборка конкретной страницы проекта:
 ```
 ./node_modules/.bin/enb make pages/index

--- a/lib/api/make.js
+++ b/lib/api/make.js
@@ -1,5 +1,6 @@
 var path = require('path'),
     vow = require('vow'),
+    vfs = require('vow-fs'),
     colors = require('../ui/colorize'),
     MakePlatform = require('../make'),
     cdir = process.cwd(),
@@ -20,6 +21,7 @@ var path = require('path'),
  * @param {Boolean}  [options.strict=true]        Строгий режим, при котором сборка завершается ошибкой,
  *                                                если запрашиваемый таргет не существует.
  * @param {Boolean}  [options.hideWarnings=false] Не выводить warning-сообщения в консоль.
+ * @param {String}   [options.buildInfoFile]      Путь к файлу, в который нужно записать информацию о сборке.
  * @returns {Promise}
  */
 module.exports = function (targets, options) {
@@ -38,8 +40,25 @@ module.exports = function (targets, options) {
     var cache = options.hasOwnProperty('cache') ? options.cache : true;
     var isStrict = options.hasOwnProperty('strict') ? options.strict : true;
     var needProfiler = options.profiler || options.profilerPercentiles;
+    var buildInfoFilename = typeof options.buildInfoFile === 'string' && path.resolve(options.buildInfoFile);
     var logger;
     var graph;
+
+    function saveBuildInfo(buildInfo) {
+        if (buildInfoFilename) {
+            var dirname = path.dirname(buildInfoFilename);
+
+            return vfs.makeDir(dirname)
+                .then(function () {
+                    return vfs.write(buildInfoFilename, JSON.stringify(buildInfo, null, 4));
+                })
+                .then(function () {
+                    return buildInfo;
+                });
+        }
+
+        return buildInfo;
+    }
 
     return makePlatform.init(root, options.mode, options.config, { graph: options.graph, profiler: needProfiler })
         .then(function () {
@@ -95,6 +114,7 @@ module.exports = function (targets, options) {
                         });
                 });
         })
+        .then(saveBuildInfo)
         .fail(function (err) {
             if (graph) {
                 console.log(graph.render());

--- a/lib/cli/make.js
+++ b/lib/cli/make.js
@@ -17,6 +17,7 @@ module.exports = function (program) {
         .option('--graph', 'draws build graph')
         .option('--profiler [type]', 'log build time of targets')
         .option('--profiler-percentiles <percentiles>', 'log percentiles of tech build times')
+        .option('--build-info-file <file>', 'write build info to JSON file')
         .description('build specified targets')
         .action(function () {
             var args = program.args.slice(0);


### PR DESCRIPTION
```shell
$ enb make --profiler --built-info-output='built-info.json'
```

`built-info.json`

```js
{
    "buildTimes": [
        {
            "target": "desktop.bundles/index/index.files",
            "techName": "files",
            "startTime": 1478605020687,
            "endTime": 1478605020722,
            "totalTime": 35,
            "selfTime": 17,
            "watingTime": 18,
            "timeline": [
                {
                    "startTime": 1478605020705,
                    "endTime": 1478605020722
                }
            ]
        },
        /* ... */
    ],
    "techMetrics": [
        {
            "tech": "files",
            "callNumber": 2,
            "buildTime": 18,
            "buildTimes": [
                17,
                1
            ],
            "buildTimePercent": 19.565217391304348
        },
        /* ... */
    ]
}
```