### PR TITLE
fix(profiler-ui): should not fail on infinite values

### DIFF
--- a/lib/ui/profiler-ui.js
+++ b/lib/ui/profiler-ui.js
@@ -2,6 +2,17 @@ var _ = require('lodash');
 var prettyMs = require('pretty-ms');
 var Table = require('cli-table');
 
+/**
+ * Convert milliseconds to a human readable string.
+ *
+ * @param {Number} value
+ *
+ * @returns {String}
+ */
+function convertMs(value) {
+    return Number.isFinite(value) ? prettyMs(value) : String(value);
+}
+
 module.exports = {
     printTechTable: function (data) {
         var printTable = new Table({
@@ -13,7 +24,7 @@ module.exports = {
                 techInfo.tech,
                 techInfo.callNumber,
                 techInfo.buildTimePercent.toFixed(3),
-                prettyMs(techInfo.buildTime)
+                convertMs(techInfo.buildTime)
             ]);
         });
 
@@ -28,9 +39,9 @@ module.exports = {
         _.map(data, function (targetInfo) {
             printTable.push([
                 targetInfo.target,
-                prettyMs(targetInfo.selfTime),
-                prettyMs(targetInfo.watingTime),
-                prettyMs(targetInfo.totalTime)
+                convertMs(targetInfo.selfTime),
+                convertMs(targetInfo.watingTime),
+                convertMs(targetInfo.totalTime)
             ]);
         });
 
@@ -46,7 +57,7 @@ module.exports = {
 
         techPercentiles.map(function (techInfo) {
             printTable.push([techInfo.tech].concat(techInfo.percentiles.map(function (item) {
-                return prettyMs(item.value);
+                return convertMs(item.value);
             })));
         });
 


### PR DESCRIPTION
If profiler is not correctly  calculate times ENB should not throw
error.

Now if profiler returns `NaN` or `Infinity` build fail with error:

```
TypeError: Expected a finite number
    at module.exports
(/project/node_modules/enb/node_modules/pretty-ms/index.js:8:9)
    at /project/node_modules/enb/lib/ui/profiler-ui.js:16:17
```