### PR TITLE
fix(server): localhost

### DIFF
--- a/lib/api/run-server.js
+++ b/lib/api/run-server.js
@@ -11,7 +11,7 @@ var path = require('path'),
  * @param {string}  [options.mode=development]   Режим сборки.
  * @param {boolean} [options.cache=true]         Учитывать кэш при запуске таска.
  * @param {number}  [options.port=8080]          Номер порта.
- * @param {string}  [options.host=0.0.0.0]       Имя хоста.
+ * @param {string}  [options.host=localhost]     Имя хоста.
  * @param {string}  [options.socket]             Путь к сокету.
  * @param {boolean} [options.hideWarnings=false] Не выводить warning-сообщения в консоль.
  * @param {string}  [options.logLevel=info]      Уровень логирования.

--- a/lib/cli/server.js
+++ b/lib/cli/server.js
@@ -14,7 +14,7 @@ program
     .option('-m, --mode <mode>', 'mode of assembly [development]')
     .option('-d, --dir <dir>', 'custom project root')
     .option('-p, --port <port>', 'socket port [8080]')
-    .option('-H, --host <host>', 'socket host [0.0.0.0]')
+    .option('-H, --host <host>', 'socket host [localhost]')
     .option('-s, --socket <socket>', 'unix socket path')
     .option('--hide-warnings', 'hides warnings')
     .option('--log-level <level>', 'log level (info, warn, error)')

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -20,7 +20,7 @@ var fs = require('fs'),
  * @param {Object} opts
  * @param {Object} opts.enbOptions
  * @param {Number} [opts.port=8080]     Номер порта.
- * @param {String} [opts.host=0.0.0.0]  Имя хоста.
+ * @param {String} [opts.host=localhost]  Имя хоста.
  * @param {String} [opts.socket]        Путь к сокету.
  * @name ENBServer
  * @constructor
@@ -31,7 +31,7 @@ module.exports = inherit({
 
        this._root = options.root;
        this._port = options.port || 8080;
-       this._host = options.host || '0.0.0.0';
+       this._host = options.host || 'localhost';
        this._socket = options.socket;
        this._enbOptions = options.enbOptions;
     },


### PR DESCRIPTION
Use `localhost` instead of `0.0.0.0`.

The users of the Windows have problems with `0.0.0.0` host.

> It in and of itself generally does not point to an individual interface. Technically, it points to "This host on this network", but that's ambiguous at best because "this network" is not defined.

Closes #547 